### PR TITLE
Use another property to disable omx.ffmpeg

### DIFF
--- a/omx/SoftFFmpegAudio.cpp
+++ b/omx/SoftFFmpegAudio.cpp
@@ -1654,6 +1654,10 @@ void SoftFFmpegAudio::onReset() {
 SoftOMXComponent* SoftFFmpegAudio::createSoftOMXComponent(
         const char *name, const OMX_CALLBACKTYPE *callbacks,
         OMX_PTR appData, OMX_COMPONENTTYPE **component) {
+
+    if (property_get_bool("debug.ffmpeg-omx.disable", 1))
+        return NULL;
+
     OMX_AUDIO_CODINGTYPE codingType = OMX_AUDIO_CodingAutoDetect;
     const char *componentRole = NULL;
     enum AVCodecID codecID = AV_CODEC_ID_NONE;

--- a/omx/SoftFFmpegVideo.cpp
+++ b/omx/SoftFFmpegVideo.cpp
@@ -830,7 +830,7 @@ SoftOMXComponent* SoftFFmpegVideo::createSoftOMXComponent(
         const char *name, const OMX_CALLBACKTYPE *callbacks,
         OMX_PTR appData, OMX_COMPONENTTYPE **component) {
 
-    if (!property_get_bool("media.sf.hwaccel", 1))
+    if (property_get_bool("debug.ffmpeg-omx.disable", 1))
         return NULL;
 
     OMX_VIDEO_CODINGTYPE codingType = OMX_VIDEO_CodingAutoDetect;


### PR DESCRIPTION
media.sf.hwaccel is for disabling HW acceleration decoder like VAAPI, so we should change it to something else and also disable audio with it